### PR TITLE
feat: auto-assign free port for multiple pg-here instances

### DIFF
--- a/bin/pg-here.mjs
+++ b/bin/pg-here.mjs
@@ -23,8 +23,7 @@ const argv = await yargs(hideBin(process.argv))
     describe: "PostgreSQL password",
   })
   .option("port", {
-    default: 55432,
-    describe: "PostgreSQL port",
+    describe: "PostgreSQL port (default: 55432)",
   })
   .option("database", {
     alias: "d",
@@ -37,7 +36,7 @@ const argv = await yargs(hideBin(process.argv))
   })
   .option("auto-port", {
     default: "true",
-    describe: "Automatically find available port if requested port is in use",
+    describe: "Auto-assign available port when default port is in use",
     type: "string",
   })
   .parse();

--- a/bin/pg-here.mjs
+++ b/bin/pg-here.mjs
@@ -36,9 +36,9 @@ const argv = await yargs(hideBin(process.argv))
     describe: "PostgreSQL version (e.g. 18.0.0 or >=17.0)",
   })
   .option("auto-port", {
-    default: true,
+    default: "true",
     describe: "Automatically find available port if requested port is in use",
-    type: "boolean",
+    type: "string",
   })
   .parse();
 
@@ -52,7 +52,7 @@ const startInstance = () =>
     password: argv.password,
     database: argv.database,
     postgresVersion: argv["pg-version"],
-    autoPort: argv["auto-port"],
+    autoPort: argv["auto-port"] === "true",
   });
 
 try {

--- a/bin/pg-here.mjs
+++ b/bin/pg-here.mjs
@@ -35,6 +35,11 @@ const argv = await yargs(hideBin(process.argv))
     default: process.env.PG_VERSION,
     describe: "PostgreSQL version (e.g. 18.0.0 or >=17.0)",
   })
+  .option("auto-port", {
+    default: true,
+    describe: "Automatically find available port if requested port is in use",
+    type: "boolean",
+  })
   .parse();
 
 let pg;
@@ -47,6 +52,7 @@ const startInstance = () =>
     password: argv.password,
     database: argv.database,
     postgresVersion: argv["pg-version"],
+    autoPort: argv["auto-port"],
   });
 
 try {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import { join, resolve } from "node:path";
+import { createServer } from "node:net";
 import { PostgresInstance } from "pg-embedded";
 import { Client } from "pg";
 
@@ -20,6 +21,7 @@ export interface PgHereOptions {
   shutdownSignals?: PgHereShutdownSignal[];
   cleanupOnShutdown?: boolean;
   enablePgStatStatements?: boolean;
+  autoPort?: boolean;
 }
 
 export interface StopPgHereOptions {
@@ -43,6 +45,31 @@ const DEFAULT_PORT = 55432;
 const DEFAULT_DATABASE = "postgres";
 const DEFAULT_SHUTDOWN_SIGNALS: PgHereShutdownSignal[] = ["SIGINT", "SIGTERM"];
 const PG_STAT_STATEMENTS_EXTENSION = "pg_stat_statements";
+
+async function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "localhost");
+  });
+}
+
+async function findAvailablePort(
+  startPort: number,
+  maxAttempts = 1000
+): Promise<number> {
+  for (let port = startPort; port < startPort + maxAttempts; port++) {
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+  throw new Error(
+    `No available port found after ${maxAttempts} attempts starting from ${startPort}`
+  );
+}
 
 export function createPgHereInstance(options: PgHereOptions = {}): PostgresInstance {
   const root = resolve(options.projectDir ?? process.cwd());
@@ -100,7 +127,18 @@ export async function stopPgHere(
 }
 
 export async function startPgHere(options: PgHereOptions = {}): Promise<PgHereHandle> {
-  const instance = createPgHereInstance(options);
+  const requestedPort = options.port ?? DEFAULT_PORT;
+
+  const autoPort = options.autoPort ?? true;
+  const port = autoPort
+    ? await findAvailablePort(requestedPort)
+    : requestedPort;
+
+  if (port !== requestedPort) {
+    console.warn(`Port ${requestedPort} is in use, using port ${port} instead`);
+  }
+
+  const instance = createPgHereInstance({ ...options, port });
   await instance.start();
 
   const database = options.database ?? DEFAULT_DATABASE;

--- a/index.ts
+++ b/index.ts
@@ -127,15 +127,17 @@ export async function stopPgHere(
 }
 
 export async function startPgHere(options: PgHereOptions = {}): Promise<PgHereHandle> {
-  const requestedPort = options.port ?? DEFAULT_PORT;
+  const autoPortEnabled = options.autoPort ?? true;
+  const usingDefaultPort = options.port === undefined;
 
-  const autoPort = options.autoPort ?? true;
-  const port = autoPort
-    ? await findAvailablePort(requestedPort)
-    : requestedPort;
+  // Only auto-assign port when using the default port
+  // If user explicitly specifies a port, use that exact port
+  const port = usingDefaultPort && autoPortEnabled
+    ? await findAvailablePort(DEFAULT_PORT)
+    : (options.port ?? DEFAULT_PORT);
 
-  if (port !== requestedPort) {
-    console.warn(`Port ${requestedPort} is in use, using port ${port} instead`);
+  if (port !== DEFAULT_PORT && usingDefaultPort) {
+    console.warn(`Port ${DEFAULT_PORT} is in use, using port ${port} instead`);
   }
 
   const instance = createPgHereInstance({ ...options, port });

--- a/scripts/pg-dev.mjs
+++ b/scripts/pg-dev.mjs
@@ -33,6 +33,11 @@ const argv = await yargs(hideBin(process.argv))
     default: process.env.PG_VERSION,
     describe: "PostgreSQL version (e.g. 18.0.0 or >=17.0)",
   })
+  .option("auto-port", {
+    default: true,
+    describe: "Automatically find available port if requested port is in use",
+    type: "boolean",
+  })
   .parse();
 
 let pg;
@@ -45,6 +50,7 @@ const startInstance = () =>
     password: argv.password,
     database: argv.database,
     postgresVersion: argv["pg-version"],
+    autoPort: argv["auto-port"],
   });
 
 try {

--- a/scripts/pg-dev.mjs
+++ b/scripts/pg-dev.mjs
@@ -34,9 +34,9 @@ const argv = await yargs(hideBin(process.argv))
     describe: "PostgreSQL version (e.g. 18.0.0 or >=17.0)",
   })
   .option("auto-port", {
-    default: true,
+    default: "true",
     describe: "Automatically find available port if requested port is in use",
-    type: "boolean",
+    type: "string",
   })
   .parse();
 
@@ -50,7 +50,7 @@ const startInstance = () =>
     password: argv.password,
     database: argv.database,
     postgresVersion: argv["pg-version"],
-    autoPort: argv["auto-port"],
+    autoPort: argv["auto-port"] === "true",
   });
 
 try {

--- a/scripts/pg-dev.mjs
+++ b/scripts/pg-dev.mjs
@@ -21,8 +21,7 @@ const argv = await yargs(hideBin(process.argv))
     describe: "PostgreSQL password",
   })
   .option("port", {
-    default: 55432,
-    describe: "PostgreSQL port",
+    describe: "PostgreSQL port (default: 55432)",
   })
   .option("database", {
     alias: "d",
@@ -35,7 +34,7 @@ const argv = await yargs(hideBin(process.argv))
   })
   .option("auto-port", {
     default: "true",
-    describe: "Automatically find available port if requested port is in use",
+    describe: "Auto-assign available port when default port is in use",
     type: "string",
   })
   .parse();


### PR DESCRIPTION
## Summary

- Automatically finds and uses the next available port when the **default port** (55432) is occupied
- Adds `--auto-port` CLI flag (default: `true`) - use `--auto-port false` to disable
- Prints a warning when a different port is assigned
- **Explicit ports are honored exactly** - if you specify `--port 55433`, that exact port is used (fails if unavailable)

## Usage

```bash
# Default behavior - auto-assign if port 55432 is in use
bunx pg-here

# Disable auto-port (will fail if default port is occupied)
bunx pg-here --auto-port false

# Explicit port - uses exactly 55433 (fails if occupied)
bunx pg-here --port 55433
```

## Implementation

- Uses Node.js `net` module to proactively check port availability before starting PostgreSQL
- Auto-port only applies when using the default port (55432)
- Explicitly specified ports are used exactly as provided for reliability
- Scans up to 1000 ports before giving up with a clear error
- Works with both `bunx pg-here` and `bun run db:up`

## Test plan

- [x] Start first instance → uses port 55432
- [x] Start second instance → auto-assigns to 55433 with warning
- [x] `--auto-port false` fails when default port is occupied
- [x] `--port 55433` uses exactly port 55433 (fails if occupied)