### PR TITLE
fix(cli): import F_OK from fs.constants for Node ESM compatibility

### DIFF
--- a/scripts/cli-error-help.mjs
+++ b/scripts/cli-error-help.mjs
@@ -8,8 +8,9 @@ import {
   readdirSync,
   rmSync,
   symlinkSync,
-  F_OK,
 } from "node:fs";
+import { constants } from "node:fs";
+const { F_OK } = constants;
 import { join } from "node:path";
 
 const LIBXML2_SONAME = "libxml2.so.2";


### PR DESCRIPTION
### Summary
- Node v25 removed `F_OK` as a direct named ESM export from `node:fs`, causing `bunx pg-here` and `npx pg-here` to crash with `SyntaxError: The requested module 'node:fs' does not provide an export named 'F_OK'`
- Fix imports `F_OK` via `fs.constants` instead, which works on all Node versions from 18+

### Test
Ran `node scripts/cli-error-help.mjs 2>&1`.

- [x] Verified on Node v18.20.8 — no errors
- [x] Verified on Node v22.22.1 (LTS) — no errors
- [x] Verified on Node v24.13.1 — no errors
- [x] Verified on Bun 1.3.10 — no errors
